### PR TITLE
Intellisense hints, Multi-lang-install, fancy select & switcher

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -10,7 +10,7 @@ const extensionsCommands = () => {
 
     cy.contains('Install from Folder').click()
 
-    cy.get('#install_directory').fill(path)
+    cy.get('#install_directory').type(path)
     cy.get('#installbutton_directory').click()
 
     cy.get('#system-message-container').contains('was successful').should('be.visible')
@@ -31,7 +31,7 @@ const extensionsCommands = () => {
 
     cy.contains('Install from URL').click()
 
-    cy.get('#install_url').fill(url)
+    cy.get('#install_url').type(url)
     cy.get('#installbutton_url').click()
 
     cy.get('#system-message-container').contains('was successful').should('be.visible')

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -87,7 +87,7 @@ const extensionsCommands = () => {
     cy.get('joomla-alert[type="warning"]').should('not.exist')
 
     cy.searchForItem(extensionName)
-    cy.get('.alert').contains(' No Matching Results ').should('exist')
+    cy.get('#installer-manage .alert').contains('No Matching Results').should('exist')
 
     cy.log('--Uninstall an extension--')
   }
@@ -135,7 +135,7 @@ const extensionsCommands = () => {
     cy.get('#system-message-container .alert').should('not.exist')
 
     cy.get('#cb0').click()
-    cy.get('#toolbar-publish button').click()
+    cy.clickToolbarButton('enable')
     cy.get('#system-message-container').should('contain', 'enabled')
 
     cy.log('--Enable Plugin--')

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -10,7 +10,7 @@ const extensionsCommands = () => {
 
     cy.contains('Install from Folder').click()
 
-    cy.get('#install_directory').type(path)
+    cy.get('#install_directory').fill(path)
     cy.get('#installbutton_directory').click()
 
     cy.get('#system-message-container').contains('was successful').should('be.visible')
@@ -34,7 +34,9 @@ const extensionsCommands = () => {
     cy.get('#install_url').type(url)
     cy.get('#installbutton_url').click()
 
-    cy.get('#system-message-container').contains('was successful').should('be.visible')
+
+
+    cy.get('#system-message-container joomla-alert').contains('was successful').should('be.visible')
 
     cy.log('--Install an extension from Url--')
   }
@@ -82,10 +84,10 @@ const extensionsCommands = () => {
     cy.get('#system-message-container').contains('was successful')
 
     // Check for warnings during install
-    cy.get('joomla-alert[@type="warning"]').should('not.be.visible')
+    cy.get('joomla-alert[type="warning"]').should('not.exist')
 
     cy.searchForItem(extensionName)
-    cy.get('#system-message-container .alert').contains(' No Matching Results ').should('exist')
+    cy.get('.alert').contains(' No Matching Results ').should('exist')
 
     cy.log('--Uninstall an extension--')
   }

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -135,9 +135,8 @@ const extensionsCommands = () => {
     cy.get('#system-message-container .alert').should('not.exist')
 
     cy.get('#cb0').click()
-    // cy.get('#toolbar-publish button').click()
-    cy.clickToolbarButton('publish')
-    cy.get('#system-message-container').contains('enabeld').should('be.visible')
+    cy.get('#toolbar-publish button').click()
+    cy.get('#system-message-container').should('contain', 'enabled')
 
     cy.log('--Enable Plugin--')
   }

--- a/src/joomla.js
+++ b/src/joomla.js
@@ -117,6 +117,13 @@ const joomlaCommands = () => {
 
     cy.get('#installCongrat', { timeout: 30000 }).should('be.visible')
 
+    cy.get('#defaultLanguagesButton').click()
+    cy.get('#system-message-container .alert-message').should('have.length', 2)
+
+    cy.get('#removeInstallationFolder').click()
+    cy.get('#removeInstallationFolder').should('not.exist')
+
+
     cy.log('Joomla is now installed')
 
     cy.log('--Install Joomla as a multi language site--')

--- a/src/joomla.js
+++ b/src/joomla.js
@@ -115,7 +115,7 @@ const joomlaCommands = () => {
 
     cy.get('#installLanguagesButton').click()
 
-    cy.get('#installCongrat', { timeout: 15000 }).should('be.visible')
+    cy.get('#installCongrat', { timeout: 30000 }).should('be.visible')
 
     cy.log('Joomla is now installed')
 

--- a/src/joomla.js
+++ b/src/joomla.js
@@ -99,16 +99,24 @@ const joomlaCommands = () => {
 
     cy.installJoomla(config)
 
+    cy.get('#installAddFeatures').then(($btn) => {
+      cy.wrap($btn.text().trim()).as('installAddFeaturesBtnText');
+    })
+
     cy.get('#installAddFeatures').click()
-    cy.contains('Install Language packages', 'h3').should('exist')
+
+    cy.get('@installAddFeaturesBtnText').then((text) => {
+      console.log(`$text: ${text}`);
+      cy.contains('legend', text).should('exist')
+    })
 
     languages.forEach((language) => {
-        cy.contains(language, 'label').click()
+        cy.contains('label', language).click()
     })
 
     cy.get('#installLanguagesButton').click()
 
-    cy.get('#installCongrat').should('be.visible')
+    cy.get('#installCongrat', { timeout: 15000 }).should('be.visible')
 
     cy.log('Joomla is now installed')
 

--- a/src/joomla.js
+++ b/src/joomla.js
@@ -106,7 +106,6 @@ const joomlaCommands = () => {
     cy.get('#installAddFeatures').click()
 
     cy.get('@installAddFeaturesBtnText').then((text) => {
-      console.log(`$text: ${text}`);
       cy.contains('legend', text).should('exist')
     })
 

--- a/src/support.js
+++ b/src/support.js
@@ -204,18 +204,31 @@ const supportCommands = () => {
   }
 
   Cypress.Commands.add('createCategory', createCategory)
-  	 
-  	 
+
+
   // select an option in a fancy
-  const selectOptionInFancySelect = (selectId, option) => 
+  const selectOptionInFancySelect = (selectId, option) =>
   {
-  	cy.get(selectId).parents('joomla-field-fancy-select').find('.choices__inner').click();
+    cy.get(selectId).parents('joomla-field-fancy-select').find('.choices__inner').click();
     cy.get(selectId).parents('joomla-field-fancy-select').find('.choices__item').contains(option).click();
   }
-  
+
   Cypress.Commands.add('selectOptionInFancySelect', selectOptionInFancySelect)
+
+
+  // toggle a switcher
+  const toggleSwitch = (switchId, value) => 
+  {
+    cy.get(switchId).find('label').contains(value).then(($label) => {
+      cy.window().then((win) => {
+        win.document.getElementById($label.attr('for')).checked = true;
+      });
+    });
+  }
+
+  Cypress.Commands.add('toggleSwitch', toggleSwitch)
 }
 
 module.exports = {
-    supportCommands
+  supportCommands
 }

--- a/src/support.js
+++ b/src/support.js
@@ -204,6 +204,16 @@ const supportCommands = () => {
   }
 
   Cypress.Commands.add('createCategory', createCategory)
+  	 
+  	 
+  // select an option in a fancy
+  const selectOptionInFancySelect = (selectId, option) => 
+  {
+  	cy.get(selectId).parents('joomla-field-fancy-select').find('.choices__inner').click();
+    cy.get(selectId).parents('joomla-field-fancy-select').find('.choices__item').contains(option).click();
+  }
+  
+  Cypress.Commands.add('selectOptionInFancySelect', selectOptionInFancySelect)
 }
 
 module.exports = {

--- a/src/support.js
+++ b/src/support.js
@@ -75,13 +75,13 @@ const supportCommands = () => {
   const checkForPhpNoticesOrWarnings = () => {
     cy.log('**Check for PHP notices and warnings**')
 
-    // cy.contains('Notice:').should('not.exists')
-    // cy.contains('<b>Notice</b>:').should('not.exists')
-    // cy.contains('Warning:').should('not.exists')
-    // cy.contains('<b>Warning</b>:').should('not.exists')
-    // cy.contains('Strict standards:').should('not.exists')
-    // cy.contains('<b>Strict standards</b>:').should('not.exists')
-    // cy.contains('The requested page can\'t be found').should('not.exists')
+    cy.contains('Notice:').should('not.exists')
+    cy.contains('<b>Notice</b>:').should('not.exists')
+    cy.contains('Warning:').should('not.exists')
+    cy.contains('<b>Warning</b>:').should('not.exists')
+    cy.contains('Strict standards:').should('not.exists')
+    cy.contains('<b>Strict standards</b>:').should('not.exists')
+    cy.contains('The requested page can\'t be found').should('not.exists')
 
     cy.log('--Check for PHP notices and warnings--')
   }

--- a/src/support.js
+++ b/src/support.js
@@ -290,11 +290,17 @@ const supportCommands = () => {
    */
   const toggleSwitch = (fieldName, valueName) =>
   {
-    cy.get('legend').parents('fieldset').find('label').contains(valueName).then(($label) => {
-      cy.window().then((win) => {
-        win.document.getElementById($label.attr('for')).checked = true;
-      });
-    })
+    cy.get('label')
+      .contains(fieldName)
+      .parents('.control-group')
+      .find('.switcher label')
+      .contains(valueName)
+      .invoke('attr', 'for')
+      .then(id => {
+        cy.window().then(win => {
+          win.document.getElementById(id).checked = true
+        })
+      })
   }
 
   Cypress.Commands.add('toggleSwitch', toggleSwitch)

--- a/src/support.js
+++ b/src/support.js
@@ -292,7 +292,7 @@ const supportCommands = () => {
   const toggleSwitch = (fieldName, valueName) =>
   {
     cy.log(`**Toggle switch** ${fieldName} to ${valueName}`)
-    cy.get('label')
+    cy.get('label:visible')
       .contains(fieldName)
       .parents('.control-group')
       .find('.switcher label')

--- a/src/support.js
+++ b/src/support.js
@@ -75,13 +75,13 @@ const supportCommands = () => {
   const checkForPhpNoticesOrWarnings = () => {
     cy.log('**Check for PHP notices and warnings**')
 
-    cy.contains('Notice:').should('not.exists')
-    cy.contains('<b>Notice</b>:').should('not.exists')
-    cy.contains('Warning:').should('not.exists')
-    cy.contains('<b>Warning</b>:').should('not.exists')
-    cy.contains('Strict standards:').should('not.exists')
-    cy.contains('<b>Strict standards</b>:').should('not.exists')
-    cy.contains('The requested page can\'t be found').should('not.exists')
+    cy.contains('Notice:').should('not.exist')
+    cy.contains('<b>Notice</b>:').should('not.exist')
+    cy.contains('Warning:').should('not.exist')
+    cy.contains('<b>Warning</b>:').should('not.exist')
+    cy.contains('Strict standards:').should('not.exist')
+    cy.contains('<b>Strict standards</b>:').should('not.exist')
+    cy.contains('The requested page can\'t be found').should('not.exist')
 
     cy.log('--Check for PHP notices and warnings--')
   }

--- a/src/support.js
+++ b/src/support.js
@@ -206,7 +206,15 @@ const supportCommands = () => {
   Cypress.Commands.add('createCategory', createCategory)
 
 
-  // select an option in a fancy
+  /**
+   * Selects an option in a fancy select field
+   *
+   * @memberof cy
+   * @method selectOptionInFancySelect
+   * @param {string} selectId - The name of the field like #jform_countries
+   * @param {string} option - The name of the value like 'Germany'
+   * @returns Chainable
+   */
   const selectOptionInFancySelect = (selectId, option) =>
   {
     cy.get(selectId).parents('joomla-field-fancy-select').find('.choices__inner').click();
@@ -216,14 +224,22 @@ const supportCommands = () => {
   Cypress.Commands.add('selectOptionInFancySelect', selectOptionInFancySelect)
 
 
-  // toggle a switcher
-  const toggleSwitch = (switchId, value) => 
+  /**
+   * Toggles a switch field
+   *
+   * @memberof cy
+   * @method toggleSwitch
+   * @param {string} fieldName - The name of the field like 'Published
+   * @param {string} valueName - The name of the value like 'Yes'
+   * @returns Chainable
+   */
+  const toggleSwitch = (fieldName, valueName) =>
   {
-    cy.get(switchId).find('label').contains(value).then(($label) => {
+    cy.get('legend').parents('fieldset').find('label').contains(valueName).then(($label) => {
       cy.window().then((win) => {
         win.document.getElementById($label.attr('for')).checked = true;
       });
-    });
+    })
   }
 
   Cypress.Commands.add('toggleSwitch', toggleSwitch)

--- a/src/support.js
+++ b/src/support.js
@@ -19,6 +19,9 @@ const supportCommands = () => {
       case "new":
         cy.get("#toolbar-new").click()
         break
+      case "enable":
+        cy.get("#toolbar-publish button").click()
+        break
       case "publish":
         cy.get("#status-group-children-publish").click()
         break

--- a/src/support.js
+++ b/src/support.js
@@ -272,6 +272,7 @@ const supportCommands = () => {
    */
   const selectOptionInFancySelect = (selectId, option) =>
   {
+    cy.log(`**Select option** ${option} in fancy select ${selectId}`)
     cy.get(selectId).parents('joomla-field-fancy-select').find('.choices__inner').click();
     cy.get(selectId).parents('joomla-field-fancy-select').find('.choices__item').contains(option).click();
   }
@@ -290,6 +291,7 @@ const supportCommands = () => {
    */
   const toggleSwitch = (fieldName, valueName) =>
   {
+    cy.log(`**Toggle switch** ${fieldName} to ${valueName}`)
     cy.get('label')
       .contains(fieldName)
       .parents('.control-group')

--- a/src/support.js
+++ b/src/support.js
@@ -89,13 +89,11 @@ const supportCommands = () => {
   const checkForPhpNoticesOrWarnings = () => {
     cy.log('**Check for PHP notices and warnings**')
 
-    cy.contains('Notice:').should('not.exist')
-    cy.contains('<b>Notice</b>:').should('not.exist')
-    cy.contains('Warning:').should('not.exist')
-    cy.contains('<b>Warning</b>:').should('not.exist')
-    cy.contains('Strict standards:').should('not.exist')
-    cy.contains('<b>Strict standards</b>:').should('not.exist')
-    cy.contains('The requested page can\'t be found').should('not.exist')
+    cy.document().then((doc) => {
+      const pageSource = doc.documentElement.innerHTML
+      const regex = /<b>Warning<\/b>:|<b>Deprecated<\/b>:|<b>Notice<\/b>:|<b>Strict standards<\/b>:/
+      expect(regex.test(pageSource)).to.equal(false)
+    })
 
     cy.log('--Check for PHP notices and warnings--')
   }

--- a/src/support.js
+++ b/src/support.js
@@ -1,6 +1,14 @@
 const supportCommands = () => {
 
-  // Clicks on a button in the toolbar
+  /**
+   * Clicks on a button in the toolbar
+   *
+   * @memberof cy
+   * @method clickToolbarButton
+   * @param {string} button
+   * @param {string} subselector
+   * @returns Chainable
+   */
   const clickToolbarButton = (button, subselector = null) => {
     cy.log('**Click on a toolbar button**')
     cy.log('Button: ' + button)
@@ -71,7 +79,13 @@ const supportCommands = () => {
   Cypress.Commands.add('clickToolbarButton', clickToolbarButton)
 
 
-  // Check for notices and warnings
+  /**
+   * Check for notices and warnings
+   *
+   * @memberof cy
+   * @method checkForPhpNoticesOrWarnings
+   * @returns Chainable
+   */
   const checkForPhpNoticesOrWarnings = () => {
     cy.log('**Check for PHP notices and warnings**')
 
@@ -88,8 +102,16 @@ const supportCommands = () => {
 
   Cypress.Commands.add('checkForPhpNoticesOrWarnings', checkForPhpNoticesOrWarnings)
 
-  // Search for an item
-  // TODO: deletes search field doesn't make sense to me in this context; RD)
+
+  /**
+   * Search for an item
+   * TODO: deletes search field doesn't make sense to me in this context; RD)
+   *
+   * @memberof cy
+   * @method searchForItem
+   * @param {string} name
+   * @returns Chainable
+   */
   const searchForItem = (name = null) => {
     cy.log('**Search for an item**')
     cy.log('Name: ' + name)
@@ -114,7 +136,16 @@ const supportCommands = () => {
 
   Cypress.Commands.add('searchForItem', searchForItem)
 
-  // set filter on list view
+
+  /**
+   * set filter on list view
+   *
+   * @memberof cy
+   * @method setFilter
+   * @param {string} name
+   * @param {string} value
+   * @returns Chainable
+   */
   const setFilter = (name, value) => {
     cy.log('**Set Filter "' + name + '" to "' + value + '"**')
 
@@ -133,7 +164,13 @@ const supportCommands = () => {
 
   Cypress.Commands.add('setFilter', setFilter)
 
-  // Check all filtered results
+  /**
+   * Check all filtered results
+   *
+   * @memberof cy
+   * @method checkAllResults
+   * @returns Chainable
+   */
   const checkAllResults = () => {
     cy.log("**Check all results**")
 
@@ -144,7 +181,19 @@ const supportCommands = () => {
 
   Cypress.Commands.add('checkAllResults', checkAllResults)
 
-  // Create a menu item
+  /**
+   * Create a menu item
+   *
+   * @memberof cy
+   * @method createMenuItem
+   * @param {string} menuTitle
+   * @param {string} menuCategory
+   * @param {string} menuItem
+   * @param {string} menu
+   * @param {string} language
+   * @param {string} extension
+   * @returns Chainable
+   */
   const createMenuItem = (menuTitle, menuCategory, menuItem, menu = 'Main Menu', language = 'All') => {
     cy.log('**Create a menu item**');
     cy.log('Menu title: ' + menuTitle)
@@ -183,7 +232,13 @@ const supportCommands = () => {
   Cypress.Commands.add('createMenuItem', createMenuItem)
 
 
-  // Create a category
+  /**
+   * @memberof cy
+   * @method createCategory
+   * @param {string} title
+   * @param {string} extension
+   * @returns Chainable
+   */
   const createCategory = (title, extension = 'com_content') =>
   {
     cy.log('**Create a category**')

--- a/src/user.js
+++ b/src/user.js
@@ -1,6 +1,15 @@
 const userCommands = () => {
 
-  // Do administrator login
+  /**
+   * Do administrator login
+   *
+   * @memberof cy
+   * @method doAdministratorLogin
+   * @param {string} user
+   * @param {string} password
+   * @param {boolean} useSnapshot
+   * @returns Chainable
+   */
   const doAdministratorLogin = (user, password, useSnapshot = true) => {
     cy.log('**Do administrator login**')
     cy.log('User: ' + user)
@@ -18,7 +27,13 @@ const userCommands = () => {
   Cypress.Commands.add('doAdministratorLogin', doAdministratorLogin)
 
 
-  // Do administrator logout
+  /**
+   * Do administrator logout
+   *
+   * @memberof cy
+   * @method doAdministratorLogout
+   * @returns Chainable
+   */
   const doAdministratorLogout = () => {
     cy.log('**Do administrator logout**')
 
@@ -32,7 +47,15 @@ const userCommands = () => {
   Cypress.Commands.add('doAdministratorLogout', doAdministratorLogout)
 
 
-  // Do frontend login
+  /**
+   * Do frontent logout
+   *
+   * @memberof cy
+   * @method doFrontendLogin
+   * @param {string} user
+   * @param {string} password
+   * @returns Chainable
+   */
   const doFrontendLogin = (user, password) => {
     cy.log('**Do frontend login**')
     cy.log('User: ' + user)
@@ -50,7 +73,13 @@ const userCommands = () => {
   Cypress.Commands.add('doFrontendLogin', doFrontendLogin)
 
 
-  // Do frontend logout
+  /**
+   * Do frontend logout
+   *
+   * @memberof cy
+   * @method doFrontendLogout
+   * @returns Chainable
+   */
   const doFrontendLogout = () => {
     cy.log('**Do frontend logout**')
 
@@ -62,8 +91,19 @@ const userCommands = () => {
 
   Cypress.Commands.add('doFrontendLogout', doFrontendLogout)
 
-
-  // Create a user
+  
+  /**
+   * Create a user
+   *
+   * @memberof cy
+   * @method createUser
+   * @param {string} name
+   * @param {string} username
+   * @param {string} password
+   * @param {string} email
+   * @param {string} userGroup
+   * @returns Chainable
+   */
   const createUser = (name, username, password, email, userGroup = 'Super Users') => {
     cy.log('**Create a user**')
     cy.log('Name: ' + name)
@@ -98,3 +138,4 @@ const userCommands = () => {
 module.exports = {
   userCommands
 }
+

--- a/src/user.js
+++ b/src/user.js
@@ -85,7 +85,7 @@ const userCommands = () => {
     cy.get('#jform_password2').clear().type(password)
 
     cy.contains('button', 'Assigned User Groups').click()
-    cy.contains('#groups label', userGroup).click()
+    cy.contains('#groups label', userGroup).find('input').check()
     cy.clickToolbarButton('save & close')
 
     cy.get('#system-message-container').contains('User saved').should('exist')


### PR DESCRIPTION
Thank you for creating the foundation for cypress! Good jump-start for the Codecept migration. 

This PR is pretty large and mixed up. I hope you can still use it. I worked with Joomla 4.3 while doing this.

I needed to make the multilang install + user creation work. While doing this, I added some hints to support code completing in IntelliJ. 

There are two new commands to support the switcher and Fancy options. 
