### PR TITLE
Issue #9 fix functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Joomla Cypress
-This is a support package to help with writing end-to-end tests for the Joomla CMS and its extensions with the Cypress 
-Helpers for using Cypress with Joomla for testing
+This is a support package that helps in writing end-to-end tests for the [Joomla CMS](https://joomla.org) and its extensions with the frontend testing tool [Cypress](/https://www.cypress.io/).
+
+The Cypress API is extended with [custom commands](https://docs.cypress.io/api/cypress-api/custom-commands).
+
+Joomla versions 4 and 5 are supported.
+
+## Usage
+You can see the usage by sample:
+* [joomla-cms](https://github.com/joomla/joomla-cms/tree/5.0-dev/tests/System) – e.g. cy.doAdministratorLogin() or cy.clickToolbarButton()
+* [quote_joomla](https://github.com/muhme/quote_joomla/test) – Joomla plus module installation

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -190,8 +190,16 @@ const extensionsCommands = () => {
 
     cy.checkAllResults()
 
+    // Click on Actions to make menu entry Unpublish visible
+    cy.get('#toolbar-status-group').click()
+
     // Make sure modules are unpublished, if we don't do this we don't get a publish message
     cy.clickToolbarButton('unpublish')
+
+    cy.checkAllResults()
+
+    // Click on Actions to make menu entry Publish visible
+    cy.get('#toolbar-status-group').click()
 
     cy.clickToolbarButton('publish')
 

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -10,7 +10,7 @@ const extensionsCommands = () => {
 
     cy.contains('Install from Folder').click()
 
-    cy.get('#install_directory').fill(path)
+    cy.get('#install_directory').clear().type(path)
     cy.get('#installbutton_directory').click()
 
     cy.get('#system-message-container').contains('was successful').should('be.visible')

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -13,11 +13,7 @@ const extensionsCommands = () => {
     cy.get('#install_directory').clear().type(path)
     cy.get('#installbutton_directory').click()
 
-    // cy.get('#system-message-container').contains('was successful').should('be.visible')
-    //   Cypress has the obscure error "assert expected <noscript> to be visible".
-    //   Maybe as the message is dynamically loaded?
-    //   Anyway, as a work-around we use a different access that works.
-    cy.get('#system-message-container').should('contain.text', 'was successful').and('be.visible')
+    cy.checkForSystemMessage('was successful')
 
     cy.log('--Install an extension from folder--')
   }
@@ -39,8 +35,7 @@ const extensionsCommands = () => {
     cy.get('#installbutton_url').click()
 
 
-
-    cy.get('#system-message-container joomla-alert').contains('was successful').should('be.visible')
+    cy.checkForSystemMessage('was successful')
 
     cy.log('--Install an extension from Url--')
   }
@@ -63,7 +58,7 @@ const extensionsCommands = () => {
 
     cy.get('#install_package').attachFile(file)
 
-    cy.get('#system-message-container').contains('was successful').should('be.visible')
+    cy.checkForSystemMessage('was successful')
 
     cy.log('--Install an extension from file upload--')
   }
@@ -85,7 +80,7 @@ const extensionsCommands = () => {
 
     cy.get('#cb0').click()
     cy.clickToolbarButton('delete')
-    cy.get('#system-message-container').contains('was successful')
+    cy.checkForSystemMessage('was successful')
 
     // Check for warnings during install
     cy.get('joomla-alert[type="warning"]').should('not.exist')
@@ -115,7 +110,7 @@ const extensionsCommands = () => {
     cy.get('#system-message-container .alert').should('not.exist')
 
     cy.get('tr.row0 input').click()
-    cy.get('#system-message-container').contains('was successful').should('be.visible')
+    cy.checkForSystemMessage('was successful')
 
     cy.log('--Install a language--')
   }
@@ -140,7 +135,7 @@ const extensionsCommands = () => {
 
     cy.get('#cb0').click()
     cy.clickToolbarButton('enable')
-    cy.get('#system-message-container').should('contain', 'enabled')
+    cy.checkForSystemMessage('enabled')
 
     cy.log('--Enable Plugin--')
   }
@@ -168,7 +163,7 @@ const extensionsCommands = () => {
 
     // cy.get('#toolbar-dropdown-save-group .button-save').click()
     cy.clickToolbarButton('save & close')
-    cy.get('#system-message-container').contains('saved').should('be.visible')
+    cy.checkForSystemMessage('saved')
 
     cy.log('--Set module position--')
   }
@@ -203,7 +198,7 @@ const extensionsCommands = () => {
 
     cy.clickToolbarButton('publish')
 
-    cy.get('#system-message-container').contains('published').should('be.visible')
+    cy.checkForSystemMessage('published')
 
     cy.log('--Publish all modules--')
   }
@@ -230,7 +225,8 @@ const extensionsCommands = () => {
     cy.get('#jform_assignment').select(0)
 
     cy.clickToolbarButton('save & close')
-    cy.get('#system-message-container').contains('saved').should('be.visible')
+
+    cy.checkForSystemMessage('saved')
 
     cy.log('--Display module on all pages--')
   }

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -100,7 +100,7 @@ const extensionsCommands = () => {
     cy.log('**Install a language**')
     cy.log('Language Name: ' + languageName)
 
-    cy.visit('/administrator/index.php?option=com_installer&view=manage')
+    cy.visit('/administrator/index.php?option=com_installer&view=languages')
 
     // TODO: Do we need this?
     cy.checkForPhpNoticesOrWarnings()

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -158,8 +158,11 @@ const extensionsCommands = () => {
 
     cy.get('tr.row0 .has-context a').click()
 
-    // TODO: herausfinden wie ich das mit dem select mache
-    // $this->selectOptionInChosen('Position', $position);
+    // as we have styled dropdown, not simple: cy.get('#jform_position').select(position)
+    // 1st click the (not visible) dropdown to open it
+    cy.get('joomla-field-fancy-select').click({force: true});
+    // 2nd select the desired (not visable) option from the dropdown
+    cy.contains(position).click({force: true});
 
     // cy.get('#toolbar-dropdown-save-group .button-save').click()
     cy.clickToolbarButton('save & close')

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -13,7 +13,11 @@ const extensionsCommands = () => {
     cy.get('#install_directory').clear().type(path)
     cy.get('#installbutton_directory').click()
 
-    cy.get('#system-message-container').contains('was successful').should('be.visible')
+    // cy.get('#system-message-container').contains('was successful').should('be.visible')
+    //   Cypress has the obscure error "assert expected <noscript> to be visible".
+    //   Maybe as the message is dynamically loaded?
+    //   Anyway, as a work-around we use a different access that works.
+    cy.get('#system-message-container').should('contain.text', 'was successful').and('be.visible')
 
     cy.log('--Install an extension from folder--')
   }

--- a/src/joomla.js
+++ b/src/joomla.js
@@ -129,9 +129,20 @@ const joomlaCommands = () => {
     cy.get('#defaultLanguagesButton').click()
     cy.get('#system-message-container .alert-message').should('have.length', 2)
 
-    cy.get('#removeInstallationFolder').click()
-    cy.get('#removeInstallationFolder').should('not.exist')
+    // delete installation
+    cy.get('body').then((body) => {
+      // Joomla 5: check element with ID 'removeInstallationFolder' exists
+      if (body.find('#removeInstallationFolder').length > 0) {
+        cy.get('#removeInstallationFolder').click()
+      } else {
+        // Joomla 4: simple click 1st button to complete installation and delete installation folder
+        cy.get('.complete-installation').eq(0).click()
+      }
+    });
 
+    // check installation is no more available
+    cy.visit("/installation", { failOnStatusCode: false }); // prevent Cypress from failing
+    cy.title().should("include", "404"); // page title have to contain 404
 
     cy.log('Joomla is now installed')
 

--- a/src/support.js
+++ b/src/support.js
@@ -103,6 +103,29 @@ const supportCommands = () => {
 
   Cypress.Commands.add('checkForPhpNoticesOrWarnings', checkForPhpNoticesOrWarnings)
 
+  /**
+   * @memberof cy
+   * @method checkForSystemMessage
+   * @param {string} contain - what we are looking for, e.g. 'published'
+   * @returns Chainable
+   */
+  const checkForSystemMessage = (contain) => {
+    cy.log('**Check for system message**')
+    cy.log('Contain: ' + contain)
+
+    // cy.get('#system-message-container').contains(contain).should('be.visible')
+    //   Cypress has the obscure error "assert expected <noscript> to be visible".
+    //   Maybe as the message is dynamically loaded?
+    //   Workarounds are:
+    //      cy.get('#system-message-container').contains(contain)
+    //      cy.get('#system-message-container').should('contain.text', contain).and('be.visible')
+    //   However, if we also access the '.alert-message' class, it works:
+    cy.get('#system-message-container .alert-message').contains(contain).should('be.visible')
+
+    cy.log('--Check for system message--')
+  }
+
+  Cypress.Commands.add('checkForSystemMessage', checkForSystemMessage)
 
   /**
    * Search for an item
@@ -225,7 +248,7 @@ const supportCommands = () => {
     // TODO: Language settings
 
     cy.clickToolbarButton('save & close')
-    cy.get('#system-message-container .alert-message').contains('saved').should('be.visible')
+    cy.checkForSystemMessage('saved')
 
     cy.log('--Create a menu item--');
   }
@@ -254,7 +277,7 @@ const supportCommands = () => {
     cy.get('#jform_title').clear().type(title)
 
     cy.clickToolbarButton('save & close')
-    cy.get('#system-message-container .alert-message').contains('saved').should('be.visible')
+    cy.checkForSystemMessage('saved')
 
     cy.log('--Create a category--')
   }

--- a/src/user.js
+++ b/src/user.js
@@ -151,7 +151,7 @@ const userCommands = () => {
     cy.contains('#groups label', userGroup).find('input').check()
     cy.clickToolbarButton('save & close')
 
-    cy.get('#system-message-container').contains('User saved').should('exist')
+    cy.checkForSystemMessage('User saved')
     cy.log('--Create a user--')
   }
 


### PR DESCRIPTION
Fixed several issues when using joomla-cypress for multilingual Joomla plus module installation.

For each problem there is a separate commit with detailed comments.

Tested against dockerized Joomla 4.3.4 and Joomla 5.0.0-rc with local Cypress 13.3.0. 

There are no differences seen in between using different browsers (Chrome v118, Electron v114 or Firefox v118).

Please note that I used Cypress for the first time and I tested it only on MacOS 14.0 (Sonoma).
