### PR TITLE
Fix #17 installExtensionFromFileUpload not working

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -54,7 +54,12 @@ const extensionsCommands = () => {
 
     cy.contains('Upload Package File').click()
 
-    document.getElementById('legacy-uploader').classList.remove('hidden')
+    // Wait until the element is available
+    cy.get('#legacy-uploader').should('exist').then(($uploader) => {
+      if ($uploader) {
+        cy.get('#legacy-uploader').invoke('removeClass', 'hidden');
+      }
+    });
 
     cy.get('#install_package').attachFile(file)
 


### PR DESCRIPTION
Error was `cypress error Cannot read properties of null (reading 'classList')`.

Fixed by waiting for the element to be present.

Tested with https://github.com/joomla/manual-examples/pull/28 on
* Intel macOS 14.5 Sonoma with branches 4.4-dev, 5.1-dev, 5.2-dev and 6.0-dev
* Microsoft Windows 11 Pro with branches 4.4-dev, 5.1-dev, 5.2-dev and 6.0-dev
* Ubuntu 24.04 Noble Numbat with branches 4.4-dev, 5.1-dev, 5.2-dev and 6.0-dev