### PR TITLE
Make joomla-cypress Joomla-release-independent

### DIFF
--- a/src/joomla.js
+++ b/src/joomla.js
@@ -62,11 +62,29 @@ const joomlaCommands = () => {
   Cypress.Commands.add('cancelTour', cancelTour)
 
 
-  // Disable Statistics
+  /**
+   * Disable Statistics Plugin
+   *
+   * Preconditions:
+   * - Admin login is required before executing this function.
+   * - This function can be executed multiple times without causing issues.
+   *
+   * Steps:
+   * 1. Navigate to the Plugins management page.
+   * 2. Search for the "System - Joomla! Statistics" plugin.
+   * 3. Open the plugin's detail view.
+   * 4. Set the plugin status to "Disabled".
+   * 5. Save and close the plugin configuration.
+  */
   const disableStatistics = () => {
+    const statisticPlugin = 'System - Joomla! Statistics';
     cy.log('**Disable Statistics**')
 
-    cy.get('.js-pstats-btn-allow-never', { timeout: 40000 }).should('be.visible').click()
+    cy.visit('/administrator/index.php?option=com_plugins&view=plugins');
+    cy.searchForItem(statisticPlugin);
+    cy.get('a').contains(statisticPlugin).click();
+    cy.get('select#jform_enabled').select('Disabled');
+    cy.get('button.button-save.btn.btn-success').click();
 
     cy.log('--Disable Statistics--')
   }


### PR DESCRIPTION
### Summary of Changes

Actual Joomla dev-4.4 branch is using joomla-cypress 0.0.16 and the branches 5.1, 5.2 and 6.0 are using joomla-cypress 1.0.3. This PR is intended to make joomla-cypress Joomla-release-independent. 

There were no much changes needed. Only `disableStatistics()` was reimplemented to work on Joomla 4.

Once this (and other open) PR is merged and the new NPM package is created, we will migrate all Joomla development branches to the new version and then only have one joomla-cypress version for Joomla System Tests.

:exclamation: If the version of the NPM package joomla-cypress for Joomla 4 is updated, the overwritten custom commands `doFrontendLogin`, `doFrontendLogout`, `doAdministratorLogin` and `doAdministratorLogout` in the file `tests/System/support/commands.js` must be deleted in to avoid endless cycles from doubled sessions.
 
### Testing Instructions

Tested was in installing `joomla-cypress` local and changing `package.json` to use the local version:
```
"joomla-cypress": "file:joomla-cypress"
```

1. Joomla System Tests
    * Branches 4.4-dev, 5.1-dev, 5.2-dev and 6.0-dev
    * Especially Joomla 4.4.6-dev System Tests was successfully
    * Using some functions like `installJoomla`, `doAdministratorLogin`, `disableStatistics` ...
2. [quote_joomla](https://github.com/muhme/quote_joomla) module installation
    * Joomla 4.4.4 and Joomla 5.0.0 (as from docker images joomla:4 and joomla:5)
    * Using some functions like `installJoomlaMultilingualSite`, `installExtensionFromFolder`, `publishModule` ...

Code changes between joomla-cypress 0.0.16 and 1.0.3 are compared. There are a lot of small changes for improvement or enhancements in functionality.

:exclamation: Since we don't have a test suite for Joomla-Cypress at the moment, there is no 100% guarantee that everything will work in Joomla 4 (and I assume that not everything will work for Joomla 4 in 0.0.16 either, as bugs have been found in the past).