### PR TITLE
Let checkForPhpNoticesOrWarnings speak

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -81,27 +81,38 @@ const supportCommands = () => {
 
   Cypress.Commands.add('clickToolbarButton', clickToolbarButton)
 
-
   /**
-   * Check for notices and warnings
+   * Check for PHP notices and warnings in the HTML page source.
+   * This command looks for keywords such as 'Deprecated' in bold followed by a colon.
+   * If such a styled keyword is found, the test fails with the PHP problem message.
    *
-   * @memberof cy
+   * Looking for:
+   * - <b>Warning</b>:
+   * - <b>Deprecated</b>:
+   * - <b>Notice</b>:
+   * - <b>Strict standards</b>:
+   *
+   * @memberof Cypress.Commands
    * @method checkForPhpNoticesOrWarnings
-   * @returns Chainable
+   * @returns {Cypress.Chainable}
    */
-  const checkForPhpNoticesOrWarnings = () => {
+  Cypress.Commands.add('checkForPhpNoticesOrWarnings', () => {
     cy.log('**Check for PHP notices and warnings**')
 
     cy.document().then((doc) => {
       const pageSource = doc.documentElement.innerHTML
-      const regex = /<b>Warning<\/b>:|<b>Deprecated<\/b>:|<b>Notice<\/b>:|<b>Strict standards<\/b>:/
-      expect(regex.test(pageSource)).to.equal(false)
+      // Search for PHP problem keywords in bold style with colon and collect the found keyword and the message
+      const regex = /<b>(Warning|Deprecated|Notice|Strict standards)<\/b>:(.*?)(<br|$)/
+      const match = regex.exec(pageSource)
+      if (match) {
+        // Directly fail with the reason, the keyword found and report the PHP problem message, e.g.
+        // Error: Unwanted PHP Warning: "Attempt to read property \"id\" on null in <b>/joomla-cms/components/com_newsfeeds/src/View/Category/HtmlView.php</b> on line <b>92</b>"
+        throw new Error(`Unwanted PHP ${match?.[1]}: ${JSON.stringify(match?.[2])}`)
+      }
     })
 
     cy.log('--Check for PHP notices and warnings--')
-  }
-
-  Cypress.Commands.add('checkForPhpNoticesOrWarnings', checkForPhpNoticesOrWarnings)
+  })
 
   /**
    * @memberof cy

--- a/src/support.js
+++ b/src/support.js
@@ -94,7 +94,7 @@ const supportCommands = () => {
    *
    * @memberof Cypress.Commands
    * @method checkForPhpNoticesOrWarnings
-   * @returns {Cypress.Chainable}
+   * @returns {void} - It does not return any value, but it is chainable with other Cypress commands.
    */
   Cypress.Commands.add('checkForPhpNoticesOrWarnings', () => {
     cy.log('**Check for PHP notices and warnings**')


### PR DESCRIPTION
Sometimes a PHP problem message directly in the HTML code causes rendering problems and
makes the error message invisible in the browser and on the screenshot. With this change
the PHP problem message is shown.

See the change by sample. Before:
```
  Test in frontend that the related items module
    1) "after each" hook for "can display a list of related articles based on the metakey field"

  0 passing (748ms)
  1 failing

  1) Test in frontend that the related items module
       "after each" hook for "can display a list of related articles based on the metakey field":
     AssertionError: expected true to equal false

Because this error occurred during a `after each` hook we are skipping all of the remaining tests.
      at Context.eval (webpack://joomla/./node_modules/joomla-cypress/src/support.js:98:0)
```

After:
```
  Test in frontend that the related items module
    1) "after each" hook for "can display a list of related articles based on the metakey field"

  0 passing (1s)
  1 failing

  1) Test in frontend that the related items module
       "after each" hook for "can display a list of related articles based on the metakey field":
     Error: Unwanted PHP Deprecated: "  DateTime::__construct(): Passing null to parameter https://github.com/joomla-projects/joomla-cypress/pull/1 ($datetime) of type string is deprecated in <b>/joomla-cms/libraries/src/Date/Date.php</b> on line <b>126</b>"

Because this error occurred during a `after each` hook we are skipping all of the remaining tests.
      at Context.eval (webpack://joomla/./node_modules/joomla-cypress/src/support.js:116:0)
```

✅ Tested with actual Joomla brnach 4.4-dev, which has 4 Deprecated/Warnings on Intel macOS 14.5 Sonoma with PHP 8.3.8, Ubuntu 24.04 LTS Noble Numbat with PHP 8.3.6 and Windows 11 with PHP 8.1.10.