### PR TITLE
Added skip tour to cancel the tour and not see it again

### DIFF
--- a/src/joomla.js
+++ b/src/joomla.js
@@ -61,6 +61,17 @@ const joomlaCommands = () => {
 
   Cypress.Commands.add('cancelTour', cancelTour)
 
+  // Skip Tour
+  const skipTour = () => {
+    cy.log('**Skip Tour**')
+
+    cy.get('.shepherd-button-secondary', { timeout: 40000 }).should('exist').click()
+
+    cy.log('--Skip Tour--')
+  }
+
+  Cypress.Commands.add('skipTour', skipTour)
+
 
   /**
    * Disable Statistics Plugin


### PR DESCRIPTION
The tours have now an auto-start functionality.
Cancelling a tour will not hide it forever. The tour will run again 10mn later.
We need to add 'skip' to not run the tour again.