### PR TITLE
Install Joomla for Stable Releases

### DIFF
--- a/src/joomla.js
+++ b/src/joomla.js
@@ -44,6 +44,16 @@ const joomlaCommands = () => {
     cy.wait(['@ajax_create', '@ajax_populate1', '@ajax_populate2', '@ajax_populate3', '@finished'], {timeout: 120000})
     cy.get('#installCongrat').should('be.visible')
 
+    // In case of Stable release the Joomla Web Installer needs one more click to complete the installation
+    cy.get('button.complete-installation').then($button => {
+      // Check if the button exists
+      if ($button.length > 0) {
+        // If there is a button, click on it and
+        // since there are two of them, just click on the first one, it doesn't matter which one
+        cy.wrap($button).first().click()
+      }
+    })
+
     cy.log('--Install Joomla--')
   }
 


### PR DESCRIPTION
The user command `installJoomla()` fails for 'Stable' Joomla releases:
```
AssertionError: Timed out retrying after 4000ms: Expected to find element: `#mod-login-username`, but never found it.
```
Reason is that the Joomla Web Installer handles different for stable releases.
For stable releases (with `DEV_STATUS = 'Stable'` in file `libraries/src/Version.php`)
the 'Congratulations!'-screen opens on every URL until either 'Open Site' or 'Open Administrator' is clicked once.

Joomla System Tests executes an administrator backend login after `installJoomla`,
but as always the 'Congratulations!'-screen opens, this fails.

This PR solves the problem by checking whether such a `button.complete-installation` exists, and if it does, it clicks on it.

It was tested that this PR dosn't harm `installJoomla` in current Joomla 4.4-dev, 5.1-dev 5.2-dev, 5.3-dev and 6.0-dev System Tests.

This PR is already implemented as *hack* in the [Joomla Branches Tester](https://github.com/muhme/joomla-branches-tester) and can be seen in action there:
```
scripts/create.sh 51
scripts/graft 51 ./Joomla_5.1.3-Stable-Full_Package.zip
```