### PR TITLE
Fix clickToolbarButton Test

### DIFF
--- a/tests/e2e/support.cy.js
+++ b/tests/e2e/support.cy.js
@@ -14,17 +14,28 @@ beforeEach(() => {
 
 describe("Test the Cypress custom commands from 'support.js' file", () => {
 
-  afterEach(() => cy.task('queryDB', "DELETE FROM #__content WHERE title = 'Test article versions'"));
-
   it('clickToolbarButton()', () => {
+    // Test the 'New' and 'Cancel' toolbar buttons with a basic click attempt
     cy.visit('/administrator/index.php?option=com_banners&view=banners');
-    cy.clickToolbarButton('new');
-    cy.clickToolbarButton('cancel');
+    cy.clickToolbarButton('New');
+    cy.clickToolbarButton('Cancel');
+    // Test the 'Save' and 'Versions' toolbar buttons using a temporarily created article
+    const testArticle = 'Test joomla-cypress clickToolbarButton()';
     cy.visit('/administrator/index.php?option=com_content&task=article.add');
-    cy.get('#jform_title').clear().type('Test article versions');
+    cy.get('#jform_title').clear().type(testArticle);
     cy.clickToolbarButton('Save');
     cy.clickToolbarButton('Versions');
     cy.get('.joomla-dialog-header').should('contain.text', 'Versions');
+    // Delete the test article, to clean-up and confirming once again that it was created with clickToolbarButton()
+    cy.visit('/administrator/index.php?option=com_content&view=articles');
+    cy.searchForItem(testArticle);
+    cy.get('#cb0').click();
+    cy.clickToolbarButton('action');
+    cy.contains('Trash').click();
+    cy.setFilter('published', 'Trashed');
+    cy.searchForItem(testArticle);
+    cy.get('#cb0').click();
+    cy.clickToolbarButton('delete');
   });
 
   it('checkForPhpNoticesOrWarnings()', () => {


### PR DESCRIPTION
In PR #40 the `clickToolbarButton()` test was introduced, but it always fails with:
```
     CypressError: `cy.task('queryDB')` failed with the following error:

The 'task' event has not been registered in the setupNodeEvents method. You must register it before using cy.task()
```

The Cypress custom task `queryDB` from Joomla System Tests is not available in testing joomla-cypress itself.

The error is reproducible when running the overall test suite or the single test:
```
npx cypress run --spec tests/e2e/support.cy.js --config-file tests/cypress.config.mjs
```

This PR manually implements the article deletion process . Additionally, comments have been added to clarify what is being tested in the clickToolbarButton() test and unified the button names with an initial uppercase letter, as capitalisation does not matter. Please ensure that tests are always run after any changes to confirm that everything continues to function correctly.