### PR TITLE
Fix clickToolbarButton Test for Joomla 4.4

### DIFF
--- a/tests/e2e/support.cy.js
+++ b/tests/e2e/support.cy.js
@@ -25,7 +25,7 @@ describe("Test the Cypress custom commands from 'support.js' file", () => {
     cy.get('#jform_title').clear().type(testArticle);
     cy.clickToolbarButton('Save');
     cy.clickToolbarButton('Versions');
-    cy.get('.joomla-dialog-header').should('contain.text', 'Versions');
+    cy.contains('h3', 'Versions').should('exist');
     // Delete the test article, to clean-up and confirming once again that it was created with clickToolbarButton()
     cy.visit('/administrator/index.php?option=com_content&view=articles');
     cy.searchForItem(testArticle);


### PR DESCRIPTION
Checked was for CSS class `joomla-dialog-container`, but in Joomla 4.4 the class name is `modal-title`.

To make the test running in Joomla 4.4 too, changed for checking for `<h3>` heading.

Please always test all active Joomla versions.