### PR TITLE
Minimised language selection for Joomla 6.0

### DIFF
--- a/src/joomla.js
+++ b/src/joomla.js
@@ -8,7 +8,6 @@
 function doInstallation(config) {
   // Load installation page and check for language dropdown
   cy.visit('installation/index.php')
-  cy.get('#jform_language').should('be.visible')
 
   // Select en-GB as installation language
   cy.get('body').then($body => {

--- a/src/joomla.js
+++ b/src/joomla.js
@@ -11,8 +11,17 @@ function doInstallation(config) {
   cy.get('#jform_language').should('be.visible')
 
   // Select en-GB as installation language
-  cy.get('#jform_language').select('en-GB')
-  cy.get('#jform_language-lbl').should('contain', 'Select Language')
+  cy.get('body').then($body => {
+    // Joomla >= 6.0 – Open minimised language selector
+    if ($body.find('button[data-joomla-dialog]').length > 0) {
+      cy.get('button[data-joomla-dialog]').click({ force: true })
+      cy.get('#jform_language').should('be.visible').select('en-GB')
+      cy.get('button[data-button-close]').click({ force: true })
+    } else {
+      // Joomla < 6.0
+      cy.get('#jform_language').should('be.visible').select('en-GB')
+    }
+  })
 
   // Fill Sitename
   cy.get('#jform_site_name').type(config.sitename)

--- a/tests/e2e/support.cy.js
+++ b/tests/e2e/support.cy.js
@@ -25,7 +25,7 @@ describe("Test the Cypress custom commands from 'support.js' file", () => {
     cy.get('#jform_title').clear().type(testArticle);
     cy.clickToolbarButton('Save');
     cy.clickToolbarButton('Versions');
-    cy.get('.joomla-dialog-header').should('contain.text', 'Versions');
+    cy.contains('h3', 'Versions').should('exist');
     // Delete the test article, to clean-up and confirming once again that it was created with clickToolbarButton()
     cy.visit('/administrator/index.php?option=com_content&view=articles');
     cy.searchForItem(testArticle);


### PR DESCRIPTION
In Joomla 6.0, the minimised language selector was introduced (see https://github.com/joomla/joomla-cms/pull/44735). This change ensures that the minimised language selector is handled correctly and works with previous Joomla versions as well.
    
* Contains #46 as needed precondition

✅ Full tested with JBT (dockerized environment) that the joomla-cypress test suite is working with Joomla 4.4-dev , 5.2-dev, 5.3-dev, 5.4-dev and 6.0-dev, before and after applying the patches:
```
# Create JBT installation with 4.4-dev, 5.2-dev, 5.3-dev, 5.4-dev and 6.0-dev
git clone https://github.com/muhme/joomla-branches-tester
cd joomla-branches-tester
scripts/create

# Make small joomla-cypress test suite fix for 4.4-dev
scripts/patch installation joomla-cypress-46

# Ugly hack to ignore targetversion in 5.3-dev ... 6.0-dev, to be able to test install languages
(cd joomla-53 && patch -p1 < ../ignore-targetplatform-on-development.patch)
(cd joomla-54 && patch -p1 < ../ignore-targetplatform-on-development.patch)
(cd joomla-60 && patch -p1 < ../ignore-targetplatform-on-development.patch)

# Test joomla-cypress test suite that everything is working 
# before the patch with 4.4-dev, 5.2-dev, 5.3-dev, 5.4-dev and 6.0-dev
scripts/test joomla-cypress

# Apply joomla-cypress patch with minimised language selecter for JBT installation env and 6.0-dev
scripts/patch installation joomla-cypress-47
scripts/patch 60 joomla-cypress-47

# Restore the installation folder manually to avoid having only half an installation folder with the following patch
cp -r installation/joomla-60/installation joomla-60

# Apply Joomla 6.0-dev patch for minimised language selector
scripts/patch 60 joomla-cms-44735

# Test again, joomla-cypress test suite is working after the patch
# with Joomla 4.4-dev, 5.2-dev, 5.3-dev, 5.4-dev and 6.0-dev
scripts/test joomla-cypress
```

(✅) Single test (and without `installJoomlaMultilingualSite()`) on Windows 11 Pro 24H2 and Laragon Cmder that the joomla-cypress test suite is working with Joomla 6.0 after applying the patches:
```
# Create Joomla 6.0-dev instance
git clone https://github.com/joomla/joomla-cms -b 6.0-dev j60
cd j60
composer i
npm ci

# Apply Joomla 6.0-dev patch for minimised language selector
gh pr checkout 44735

# Create joomla-cypress for test suite
cd node_modules
rm -rf joomla-cypress
git clone https://github.com/joomla-projects/joomla-cypress
cd joomla-cypress
npm ci

# Apply joomla-cypress patch with minimised language selecter
gh pr checkout 47

# Configure target joomla
cp tests\cypress.config.dist.mjs tests\cypress.config.mjs
# Configure e.g.:
#   db_user: 'root',
#   db_password: '',
#   instance: 60,
#   installationPath: 'C:/laragon/www/j60'
#   baseUrl: 'http://j60.test',

# Run joomla-cypress test suite
# Unfortunally we have to exlude installJoomlaMultilingualSite() on Windows as #37909
set CYPRESS_SKIP_INSTALL_LANGUAGES=1
npm test
```

## Testing Instructions
Test joomly-cypress test suite is running after applying https://github.com/joomla/joomla-cms/pull/44735 and #47 on all active Joomla branches 4.4-dev , 5.2-dev, 5.3-dev, 5.4-dev and 6.0-dev.

## Next Steps
After successful test and #46 and #47 merge, a new NPM release must be created. The new joomla-cypress release can then be used in Joomla 6.0-dev. 